### PR TITLE
Added NuShell squash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,7 @@ The version is based on the branch type:
 
 Release is invoked by a push tag event. The tag value has to have the SemVer format with three parts: `v*.*.*`
 The release is automatically called from the build  workflow using a dispatch event call after the build workflow pushes a tag to the main branch.
+
+## Git Hooks scripts
+
+The use of git hooks has been documented in [doc/git-hooks.md](doc/git-hooks.md) file.

--- a/doc/git-commands.md
+++ b/doc/git-commands.md
@@ -1,0 +1,29 @@
+# Git Commands
+
+## Git Squash
+
+It squashes the last N commits into one. Commits messages are combined into one.
+
+```nushell
+# display pretty log history
+> g ll
+49c5b03 (HEAD -> feat/squash-cmd) docs(githook): Reference in main README to docs/git-hook.md added
+c8506e4 test(git): draft git nushell commands
+e4f0f9a (origin/main, origin/HEAD, main) docs(githook): Document the use of prepare-commit-hook
+c6f7631 (tag: v0.0.4) ci(version): Bumped version to 0.0.4
+...
+
+# import agit module
+> use scripts/agit
+
+# squash last 2 commits
+# This will open the configured editor to review commit messages.
+> agit git-squash-last 2
+Commit message is compliant with Conventional Commits
+[feat/squash-cmd 60df5c8] docs(githook): Reference in main README to docs/git-hook.md added
+ 8 files changed, 369 insertions(+), 3 deletions(-)
+ create mode 100644 scripts/agit/common.nu
+ create mode 100644 scripts/agit/complete.nu
+ create mode 100644 scripts/agit/git-flow.nu
+ create mode 100644 scripts/agit/stat.nu
+```

--- a/scripts/agit/common.nu
+++ b/scripts/agit/common.nu
@@ -1,0 +1,15 @@
+export def agree [
+    prompt
+    --default-not (-n)
+] {
+    let prompt = if ($prompt | str ends-with '!') {
+        $'(ansi red)($prompt)(ansi reset)'
+    } else {
+        $'($prompt)'
+    }
+    (if $default_not { [no yes] } else { [yes no] } | input list $prompt) == 'yes'
+}
+
+export def tips [msg] {
+    print -e $"(ansi light_gray)($msg)(ansi reset)"
+}

--- a/scripts/agit/complete.nu
+++ b/scripts/agit/complete.nu
@@ -1,0 +1,35 @@
+export def cmpl-git-log [] {
+    git log -n 32 --pretty=%h»¦«%s
+    | lines
+    | split column "»¦«" value description
+    #| each { $"($in.value) # ($in.description)"}
+    | { completions: $in, options: { sort: false } }
+}
+
+export def cmpl-git-log-all [] {
+    git log --all -n 32 --pretty=%h»¦«%d»¦«%s
+    | lines
+    | split column "»¦«" value branch description
+    | each {|x| $x | update description $"($x.branch) ($x.description)" }
+    | { completions: $in, options: { sort: false } }
+}
+
+export def cmpl-git-branch-files [context: string, offset:int] {
+    let token = $context | split row ' '
+    let branch = $token | get 1
+    let files = $token | skip 2
+    git ls-tree -r --name-only $branch
+    | lines
+    | filter {|x| not ($x in $files)}
+}
+
+export def cmpl-git-branches [] {
+    git branch
+    | lines
+    | filter {|x| not ($x | str starts-with '*')}
+    | each {|x| $"($x|str trim)"}
+}
+
+export def cmpl-git-remotes [] {
+  ^git remote | lines | each { |line| $line | str trim }
+}

--- a/scripts/agit/core.nu
+++ b/scripts/agit/core.nu
@@ -1,3 +1,7 @@
+use common.nu *
+use complete.nu *
+use stat.nu *
+
 # Check if last commit message complies with conventional commits specs
 export def is_conventional_commit [] {
   let subject = git show -s --format="%s"
@@ -36,4 +40,38 @@ export def is_conventional_commit_hook [commit_msg_file] {
   #   returns false:
   #     another update
   $commit_msg | parse --regex '(?P<type>^[a-z]+)(?P<scope>\(.*\))?(?P<break>!?):(?P<desc>.*$)' | is-not-empty
+}
+
+export def git-squash-last [
+    num:int
+] {
+    let l = git log  --pretty=»»¦««%s»¦«%b -n $num
+    | split row '»»¦««' | slice 1..
+    | split column '»¦«' message body
+    | each { $"($in.message)\n\n($in.body)" }
+    | str join "\n===\n"
+    git reset --soft $"HEAD~($num)"
+    git commit --edit -m $l
+}
+
+export def git-merge [
+    branch?:            string@cmpl-git-branches
+    --abort (-a)
+    --continue (-c)
+    --quit (-q)
+    --squash (-s)
+    --fast-farward (-f)
+    --remote (-r)='origin':  string@cmpl-git-remotes
+] {
+    mut args = []
+    if $squash { $args ++= [--squash] }
+    if $fast_farward { $args ++= [--ff] } else { $args ++= [--no-ff] }
+    if ($branch | is-empty) {
+        git merge ...$args $"($remote)/(git_main_branch)"
+    } else {
+        git merge ...$args $branch
+    }
+    if $squash {
+        git commit -v
+    }
 }

--- a/scripts/agit/git-flow.nu
+++ b/scripts/agit/git-flow.nu
@@ -1,0 +1,256 @@
+use utils.nu *
+use core.nu *
+use complete.nu *
+use stat.nu *
+
+export-env {
+    $env.GIT_FLOW = {
+        branches: {
+            dev: dev
+            main: main
+            release: release
+            hotfix: hotfix
+            feature: feature
+        }
+        separator: '/'
+    }
+}
+
+def git-kind-select [kind] {
+    git branch
+    | lines
+    | filter { $in | str starts-with '*' | not $in }
+    | each {|x| $"($x|str trim)"}
+    | filter {|x|
+        let branches = $env.GIT_FLOW.branches
+        let sep = $env.GIT_FLOW.separator
+        $x | str starts-with $"($branches | get $kind)($sep)"
+    }
+}
+
+def cmpl-git-features [] {
+    git-kind-select feature
+}
+
+export def git-kind-branches [kind] {
+    let branches = $env.GIT_FLOW.branches
+    let sep = $env.GIT_FLOW.separator
+    let curr = (_git_status).branch
+    mut obj = $curr
+    if not ($obj | str starts-with $"($branches | get $kind)($sep)") {
+        let r = git-kind-select $kind
+        $obj = if ($r | is-empty) { $r } else { $r | input list $"There are no ($kind) currently, pick?" }
+    }
+    {
+        curr: $curr
+        $kind: $obj
+        dev: $branches.dev
+        main: $branches.main
+    }
+}
+
+export def gitflow-open-feature [
+    name: string
+] {
+    let b = $env.GIT_FLOW.branches
+    let sep = $env.GIT_FLOW.separator
+    git checkout -b $"($b.feature)($sep)($name)" $b.dev
+}
+
+export def gitflow-close-feature [
+    --fast-farward (-f)
+] {
+    let b = git-kind-branches feature
+    if ($b.feature | is-empty) {
+        print $"(ansi grey)There are no feature branches.(ansi reset)"
+        return
+    }
+    git checkout $b.dev
+    let f = if $fast_farward {[--ff]} else {[--no-ff]}
+    git merge ...$f $b.feature
+    let remote = git remote show
+    git push -u $remote $b.dev
+    git branch -d $b.feature
+    git checkout $b.dev
+}
+
+export def gitflow-resolve-feature [
+] {
+    git checkout $env.GIT_FLOW.branches.dev
+    git add .
+    git commit
+    git push
+}
+
+export def gitflow-release [
+    tag?: string
+    --action(-a): closure
+] {
+    let b = $env.GIT_FLOW.branches
+    let sep = $env.GIT_FLOW.separator
+    let remote = git remote show
+    git checkout $b.dev
+    git push -u $remote $b.dev
+
+    let rb = if ($tag | is-empty) {
+        $b.dev
+    } else {
+        let rb = $"($b.release)($sep)($tag)"
+        git checkout -b $rb $b.dev
+
+        if ($action | is-not-empty) {
+            do $action $tag
+        }
+        do -i { git commit -a -m $"Bumped version number to ($tag)" }
+
+        $rb
+    }
+
+    git checkout $b.main
+    let f = if ($tag | is-empty) {[--ff]} else {[--no-ff]}
+    git merge ...$f $rb
+    git push -u $remote $b.main
+    if ($tag | is-not-empty) {
+        git tag -a $tag
+        git push $remote tag $tag
+
+        do -i { git branch -d $rb }
+    }
+
+    git checkout $b.dev
+}
+
+
+export def gitflow-open-hotfix [
+    tag: string
+] {
+    let b = $env.GIT_FLOW.branches
+    let sep = $env.GIT_FLOW.separator
+    let rb = $"($b.hotfix)($sep)($tag)"
+    git checkout -b $rb $b.main
+    # ... bump
+    git commit -a -m $"Bumped version number to ($tag)"
+}
+
+
+export def gitflow-close-hotfix [
+    message?: string
+] {
+
+    let b = git-kind-branches hotfix
+    if ($b.hotfix | is-empty) {
+        print $"(ansi grey)There are no hotfix branches.(ansi reset)"
+        return
+    }
+    git checkout $b.hotfix
+
+    do -i { git commit -m $"Fixed: ($message)" }
+
+    let remote = git remote show
+    let f = if ($message | is-empty) {[--ff]} else {[--no-ff]}
+    git checkout $b.main
+    git merge ...$f $b.hotfix
+    git push -u $remote $b.main
+    if ($message | is-not-empty) {
+        let sep = $env.GIT_FLOW.separator
+        let t = $b.hotfix | split row $sep | slice 1.. | str join $sep
+        git tag -a $t
+        git push $remote tag $t
+    }
+
+    git checkout $b.dev
+    git merge ...$f $b.hotfix
+
+    git branch -d $b.hotfix
+}
+
+export def gitlab-open-feature [
+    name: string
+    --local(-l)
+] {
+    let b = $env.GIT_FLOW.branches
+    let sep = $env.GIT_FLOW.separator
+    let remote = git remote show
+    let f = $"($b.feature)($sep)($name)"
+    git checkout -b $f $b.main
+    if not $local {
+        git push -u $remote $f
+    }
+}
+
+export def gitlab-close-feature [
+    --fast-farward (-f)
+    --local(-l)
+] {
+    let b = git-kind-branches feature
+    if ($b.feature | is-empty) {
+        print $"(ansi grey)There are no feature branches.(ansi reset)"
+        return
+    }
+
+    let remote = git remote show
+    git checkout $b.main
+    if $local {
+        let f = if $fast_farward {[--ff]} else {[--no-ff]}
+        git merge ...$f $b.feature
+        git push
+    } else {
+        git pull
+    }
+    git branch -D $b.feature
+    let rb = $'($remote)/($b.feature)'
+    if $rb in (remote_branches) {
+        git branch -D -r $rb
+        git push $remote -d $b.feature
+    }
+}
+
+export def gitlab-resolve-feature [
+] {
+    git checkout $env.GIT_FLOW.branches.main
+    git add .
+    git commit
+    git push
+}
+
+
+export def gitlab-release [
+    tag?: string
+    --from(-f): string
+    --to(-t): string = 'pre-production'
+    --action(-a): closure
+] {
+    let b = $env.GIT_FLOW.branches
+    let sep = $env.GIT_FLOW.separator
+    let remote = git remote show
+    let $from = if ($from | is-empty) { $b.main } else { $from }
+    git checkout $from
+    git push -u $remote $from
+
+    let rb = if ($tag | is-empty) {
+        $from
+    } else {
+        let rb = $"($b.release)($sep)($tag)"
+        git checkout -b $rb $from
+
+        if ($action | is-not-empty) {
+            do $action $tag
+        }
+        do -i { git commit -a -m $"Bumped version number to ($tag)" }
+
+        $rb
+    }
+
+    git checkout $to
+    let f = if ($tag | is-empty) {[--ff]} else {[--no-ff]}
+    git merge ...$f $rb
+    git push -u $remote $rb
+    if ($tag | is-not-empty) {
+        git tag -a $tag
+        git push $remote tag $tag
+
+        do -i { git branch -d $rb }
+    }
+
+    git checkout $b.main
+}

--- a/scripts/agit/mod.nu
+++ b/scripts/agit/mod.nu
@@ -1,4 +1,22 @@
-
-export module ./core.nu
 export module ./increment.nu
 export module ./utils.nu
+
+export use stat.nu *
+export use utils.nu *
+export use core.nu *
+export use complete.nu *
+
+export-env {
+    $env.GIT_COMMIT_TYPE = {
+        feat: 'feat: {}'
+        fix: 'fix: {}'
+        docs: 'docs: {}'
+        style: 'style: {}'
+        refactor: 'refactor: {}'
+        perf: 'perf: {}'
+        test: 'test: {}'
+        chore: 'chore: {}'
+    }
+    export use git-flow.nu
+}
+

--- a/scripts/githooks/prepare-commit-msg
+++ b/scripts/githooks/prepare-commit-msg
@@ -31,7 +31,7 @@ use "../../scripts/agit"
 def main [COMMIT_MSG_FILE: string, 
           COMMIT_SOURCE?: string, 
           SHA1?: string] {
-  let res =  match (agit core is_conventional_commit_hook $COMMIT_MSG_FILE ) {
+  let res =  match (agit is_conventional_commit_hook $COMMIT_MSG_FILE ) {
     false => {
       let subject = open $COMMIT_MSG_FILE | lines | first
       print "Commit message is not compliant with Conventional Commits"


### PR DESCRIPTION
The command `git-squash-last` is part of the agit NuShell module and it is invoked like this

```
# import agit module
> use scripts/agit

# squash last 2 commits
# This will open the configured editor to review commit messages.
> agit git-squash-last 2
Commit message is compliant with Conventional Commits
[feat/squash-cmd 60df5c8] docs(githook): Reference in main README to docs/git-hook.md added
 8 files changed, 369 insertions(+), 3 deletions(-)
 create mode 100644 scripts/agit/common.nu
 create mode 100644 scripts/agit/complete.nu
 create mode 100644 scripts/agit/git-flow.nu
 create mode 100644 scripts/agit/stat.nu
```